### PR TITLE
Fixed typo error

### DIFF
--- a/minuitwrp/graphics_fbdev.cpp
+++ b/minuitwrp/graphics_fbdev.cpp
@@ -59,7 +59,7 @@ minui_backend* open_fbdev() {
     return &my_backend;
 }
 
-static void fbdev_blank(minui_backend* backend __unused, bool blank)
+static void fbdev_blank(minui_backend* backend __unused, bool blank __unused)
 {
 #if defined(TW_NO_SCREEN_BLANK) && defined(TW_BRIGHTNESS_PATH) && defined(TW_MAX_BRIGHTNESS)
     int fd;


### PR DESCRIPTION
This error fixes the building of the twrp if using mka adbd recoveryimage on grus (Xiaomi Mi9SE)

