### PR TITLE
recovery: add full password hashing support

### DIFF
--- a/gui/Android.mk
+++ b/gui/Android.mk
@@ -102,7 +102,8 @@ endif
 LOCAL_C_INCLUDES += \
     bionic \
     system/core/include \
-    system/core/libpixelflinger/include
+    system/core/libpixelflinger/include \
+    external/boringssl/src/include
 
 ifeq ($(shell test $(PLATFORM_SDK_VERSION) -lt 23; echo $$?),0)
     LOCAL_C_INCLUDES += external/stlport/stlport


### PR DESCRIPTION
1. user sets a password/pattern (ref. as "type" here)
2. a random salt gets generated
3. salt + password/pattern will be hashed (sha256, openssl)
4. type + salt + hash gets stored within the SHRP image
5. on SHRP boot user enters password/pattern for unlock
6. SHRP will read the data file and reconstructs:
   type, salt and hash from it
7. the pass/pattern entered by the user will be checked:
   - by the reconstructed salt (from data file)
   - calculated hash (salt + entered pass/pattern)
   - comparing the whole result with the data file

note:
the whole "security" setting within a recovery is just
useful for one specific use-case:

*protecting your phone when the attacker do not have access
to it by fastboot*

as soon as the attacker has access by fastboot any security
setting is useless as you can overwrite the recovery by whatever
you like. that's a matter of fact which simply comes with
unlocking the bootloader.

anyways this implementation ensures the pass is not stored in
clear-text anymore and so makes it a little bit harder for an
attacker. hashing instead of clear-text is also needed to
protect your android, as long as we can assume that the average
user will use the same pass/pattern for android as for the
recovery (if you would know one you would know both).

Signed-off-by: steadfasterX <steadfasterX@gmail.com>