### PR TITLE
recovery: secure MTP and ADB when pass/pattern set

### DIFF
--- a/etc/init.rc
+++ b/etc/init.rc
@@ -110,13 +110,13 @@ service adbd /sbin/adbd --root_seclabel=u:r:su:s0 --device_banner=recovery
     seclabel u:r:adbd:s0
 
 # Always start adbd on userdebug and eng builds
-on property:ro.debuggable=1
+on property:ro.debuggable=1 && property:shrp.lock=0
     #write /sys/class/android_usb/android0/enable 1
     #start adbd
     setprop service.adb.root 1
 
 # Restart adbd so it can run as root
-on property:service.adb.root=1
+on property:service.adb.root=1 && property:shrp.lock=0
     write /sys/class/android_usb/android0/enable 0
     restart adbd
     write /sys/class/android_usb/android0/enable 1

--- a/gui/action.cpp
+++ b/gui/action.cpp
@@ -2012,13 +2012,24 @@ int GUIAction::changefilesystem(std::string arg __unused)
 int GUIAction::startmtp(std::string arg __unused)
 {
 	int op_status = 0;
+	int shrp_lock_val;
 
-	operation_start("Start MTP");
-	if (PartitionManager.Enable_MTP())
-		op_status = 0; // success
-	else
-		op_status = 1; // fail
-
+	shrp_lock_val = property_get_int64("shrp.lock", -1);
+	if(shrp_lock_val==-1){
+	    shrp_lock_val = DataManager::GetIntValue("shrp_lock");
+	    std::string shrp_lock_val_s = std::to_string(shrp_lock_val);
+	    property_set("shrp.lock", shrp_lock_val_s.c_str()); // needed as lockCheck() hasn't set it obviously
+	}
+	if(shrp_lock_val==0) {
+	    operation_start("Start MTP");
+	    if (PartitionManager.Enable_MTP())
+		    op_status = 0; // success
+	    else
+		    op_status = 1; // fail
+	}else{
+	    operation_start("Will not start MTP as device is locked");
+	    op_status = 1; // fail
+	}
 	operation_end(op_status);
 	return 0;
 }

--- a/twrp.cpp
+++ b/twrp.cpp
@@ -82,6 +82,7 @@ void lockCheck(){
 			DataManager::SetValue("patt_lock_enabled",0);
 			DataManager::SetValue("c_new",0);
 			DataManager::SetValue("c_new_pattern",0);
+			property_set("shrp.lock","1");
 			PartitionManager.Disable_MTP();
 		}else if(hello[0]=='2'){
 			//Pattern Protected Recovery
@@ -90,6 +91,7 @@ void lockCheck(){
 			DataManager::SetValue("patt_lock_enabled",1);
 			DataManager::SetValue("c_new",0);
 			DataManager::SetValue("c_new_pattern",0);
+			property_set("shrp.lock","1");
 			//DataManager::SetValue("main_pass",1);
 			PartitionManager.Disable_MTP();
 		}else{
@@ -99,6 +101,7 @@ void lockCheck(){
 			DataManager::SetValue("patt_lock_enabled",0);
 			DataManager::SetValue("c_new",1);
 			DataManager::SetValue("c_new_pattern",1);
+			property_set("shrp.lock","0");
 		}
 	}else{
 		//Unprotected Recovery
@@ -107,6 +110,7 @@ void lockCheck(){
 		DataManager::SetValue("patt_lock_enabled",0);
 		DataManager::SetValue("c_new",1);
 		DataManager::SetValue("c_new_pattern",1);
+		property_set("shrp.lock","0");
 	}
 }
 void shrp_lockscreen_date(){//SHRP Buutiful Lockscreen Date View
@@ -430,9 +434,11 @@ int main(int argc, char **argv) {
 	}
 
 #ifdef TW_HAS_MTP
-	char mtp_crash_check[PROPERTY_VALUE_MAX];
-	property_get("mtp.crash_check", mtp_crash_check, "0");
-	if (DataManager::GetIntValue("tw_mtp_enabled")
+	if(DataManager::GetIntValue("lock_enabled") == 0) {
+	    LOGINFO("SHRP is unlocked; processing MTP now.\n");
+	    char mtp_crash_check[PROPERTY_VALUE_MAX];
+	    property_get("mtp.crash_check", mtp_crash_check, "0");
+	    if (DataManager::GetIntValue("tw_mtp_enabled")
 			&& !strcmp(mtp_crash_check, "0") && !crash_counter
 			&& (!DataManager::GetIntValue(TW_IS_ENCRYPTED) || DataManager::GetIntValue(TW_IS_DECRYPTED))) {
 		property_set("mtp.crash_check", "1");
@@ -442,13 +448,16 @@ int main(int argc, char **argv) {
 		else
 			gui_msg("mtp_enabled=MTP Enabled");
 		property_set("mtp.crash_check", "0");
-	} else if (strcmp(mtp_crash_check, "0")) {
+	    } else if (strcmp(mtp_crash_check, "0")) {
 		gui_warn("mtp_crash=MTP Crashed, not starting MTP on boot.");
 		DataManager::SetValue("tw_mtp_enabled", 0);
 		PartitionManager.Disable_MTP();
-	} else if (crash_counter == 1) {
+	    } else if (crash_counter == 1) {
 		LOGINFO("TWRP crashed; disabling MTP as a precaution.\n");
 		PartitionManager.Disable_MTP();
+	    }
+	}else{
+	    LOGINFO("SHRP is locked; MTP is not allowing to start.\n");
 	}
 #endif
 


### PR DESCRIPTION
ADB
-----
1. on boot SHRP will check if pass/pattern is set
2. depending on 1. the property "shrp.lock" will be set
   to 0 (off) or 1 (on)
3. ADB will not start when a pass/pattern is set
4. when the correct pass/pattern is entered shrp.lock will
   change to 0
5. and finally on property shrp.lock=0 ADB will start

MTP
-----
1. same as for ADB
2. depending on 1. "lock_enabled" is set to 0 (off) or 1 (on)
3. MTP will not start when a pass/pattern is set (boot)
4. MTP will not start until the correct pass/pattern has been
   entered (handled directly within startmtp function)
5. triggered by ADB MTP will be started*

for 5. a better implementation would be to move the whole
"#ifdef TW_HAS_MTP" part of main() in twrp.cpp to a new function
and calling that function there AND within lockCheck() to
handle non-MTP devices properly.

note:
the whole "security" setting within a recovery is just
useful for one specific use-case:

*protecting your phone when the attacker do not have access
to it by fastboot*

as soon as the attacker has access by fastboot any security
setting is useless as you can overwrite the recovery by whatever
you like. that's a matter of fact which simply comes with
unlocking the bootloader.

anyways this implementation ensures that an attacker NEEDS to
replace the recovery in order to access your files and so makes
it a little bit harder for being hacked.

Signed-off-by: steadfasterX <steadfasterX@gmail.com>