### PR TITLE
magisk: fix typo

### DIFF
--- a/gui/theme/shrp_portrait_hdpi/magisk/mm
+++ b/gui/theme/shrp_portrait_hdpi/magisk/mm
@@ -14,7 +14,7 @@ mountPath=/_magisk
 img=/data/adb/magisk.img
 [ -f $img ] || img=/data/adb/modules
 
-trap 'exxit $?' EXIT
+trap 'exit $?' EXIT
 
 umask 022
 set -euo pipefail


### PR DESCRIPTION
recovery.log:
> "mm: exxit: not found"

code works even with that typo though
