### PR TITLE
recovery: re-enable auto-name for backups

### DIFF
--- a/twrp-functions.cpp
+++ b/twrp-functions.cpp
@@ -992,12 +992,12 @@ string TWFunc::System_Property_Get(string Prop_Name) {
 }
 
 void TWFunc::Auto_Generate_Backup_Name() {
-	//string propvalue = System_Property_Get("ro.build.display.id");
-	//if (propvalue.empty()) {
+	string propvalue = System_Property_Get("ro.build.display.id");
+	if (propvalue.empty()) {
 	DataManager::SetValue(TW_BACKUP_NAME, Get_Current_Date());
 	return;
-	//}
-	/*else {
+	}
+	else {
 		//remove periods from build display so it doesn't confuse the extension code
 		propvalue.erase(remove(propvalue.begin(), propvalue.end(), '.'), propvalue.end());
 	}
@@ -1018,7 +1018,7 @@ void TWFunc::Auto_Generate_Backup_Name() {
 		DataManager::SetValue(TW_BACKUP_NAME, Get_Current_Date());
 	} else {
 		DataManager::SetValue(TW_BACKUP_NAME, Backup_Name);
-	}*/
+	}
 }
 
 void TWFunc::Fixup_Time_On_Boot(const string& time_paths /* = "" */)


### PR DESCRIPTION
based on the findings in build.prop of /system