### PR TITLE
minitwrp: Added vibrator HAL 1.0 support

### DIFF
--- a/minuitwrp/Android.mk
+++ b/minuitwrp/Android.mk
@@ -10,10 +10,17 @@ LOCAL_SRC_FILES := \
     graphics_utils.cpp \
     events.cpp
 
+ifeq ($(TW_SUPPORT_INPUT_1_0_HAPTICS),true)
+    ifeq ($(shell test $(PLATFORM_SDK_VERSION) -ge 28; echo $$?),0)
+        LOCAL_SHARED_LIBRARIES += android.hardware.vibrator@1.0 libhidlbase
+        LOCAL_CFLAGS += -DUSE_QTI_HAPTICS_1_0
+    endif
+endif
+
 ifeq ($(TW_SUPPORT_INPUT_1_2_HAPTICS),true)
     ifeq ($(shell test $(PLATFORM_SDK_VERSION) -ge 28; echo $$?),0)
         LOCAL_SHARED_LIBRARIES += android.hardware.vibrator@1.2 libhidlbase
-        LOCAL_CFLAGS += -DUSE_QTI_HAPTICS
+        LOCAL_CFLAGS += -DUSE_QTI_HAPTICS_1_2
     endif
 endif
 

--- a/minuitwrp/events.cpp
+++ b/minuitwrp/events.cpp
@@ -28,7 +28,11 @@
 #include <string.h>
 #include <fstream>
 
-#ifdef USE_QTI_HAPTICS
+#ifdef USE_QTI_HAPTICS_1_0
+#include <android/hardware/vibrator/1.0/IVibrator.h>
+#endif
+
+#ifdef USE_QTI_HAPTICS_1_2
 #include <android/hardware/vibrator/1.2/IVibrator.h>
 #endif
 
@@ -135,8 +139,13 @@ int vibrate(int timeout_ms)
     char tout[6];
     sprintf(tout, "%i", timeout_ms);
 
-#ifdef USE_QTI_HAPTICS
-    android::sp<android::hardware::vibrator::V1_2::IVibrator> vib = android::hardware::vibrator::V1_2::IVibrator::getService();
+#ifdef USE_QTI_HAPTICS_1_0
+    android::sp<android::hardware::vibrator::V1_0::IVibrator> vib = android::hardware::vibrator::V1_0::IVibrator::getService();
+    if (vib != nullptr) {
+        vib->on((uint32_t)timeout_ms);
+    }
+#elif USE_QTI_HAPTICS_1_2
+        android::sp<android::hardware::vibrator::V1_2::IVibrator> vib = android::hardware::vibrator::V1_2::IVibrator::getService();
     if (vib != nullptr) {
         vib->on((uint32_t)timeout_ms);
     }


### PR DESCRIPTION
on some sm8150 devices, the vendor does not use the vibrator HAL of 1.2.
Although the vibrator service is injected, it still cannot control the vibrator with the service.

Signed-off-by: gesangtome <gesangtome@foxmail.com>